### PR TITLE
Improve Motusolve layout

### DIFF
--- a/vue-src/index.html
+++ b/vue-src/index.html
@@ -3,9 +3,12 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
 	</head>
 
-	<body>
+	<body class="min-h-screen flex items-center justify-center bg-gray-50 font-[Inter]">
 		<div id="app"></div>
 		<script type="module" src="/src/main.js"></script>
 		<script src="%PUBLIC_URL%/__neutralino_globals.js"></script>

--- a/vue-src/src/components/Letter.vue
+++ b/vue-src/src/components/Letter.vue
@@ -3,7 +3,7 @@
 		<button class="absolute top-0 right-0 w-4 h-4 p-0 text-xs cursor-pointer leading-none text-red-500 hover:text-red-700" tabindex="-1" @click="$emit('onRemove')">×</button>
 
 		<!-- input centré -->
-		<input class="w-full h-full text-center outline-none uppercase border rounded" :value="letter" type="text" maxlength="1" @input="handleInput" />
+		<input class="w-full h-full text-center outline-none uppercase border rounded border-gray-300 focus:ring-2 focus:ring-amber-500" :value="letter" type="text" maxlength="1" @input="handleInput" />
 	</div>
 </template>
 

--- a/vue-src/src/components/LetterGroup.vue
+++ b/vue-src/src/components/LetterGroup.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex flex-row gap-1">
+	<div class="flex flex-row gap-1 bg-gray-100 p-2 rounded justify-center">
 		<Letter v-for="(letter, i) in letters" :key="letter" :letter="letter" @onChange="letter => onChange(letter, i)" @onRemove="removeLetter(i)" />
 		<LetterPlus @click="addLetter" />
 	</div>

--- a/vue-src/src/components/LetterPlus.vue
+++ b/vue-src/src/components/LetterPlus.vue
@@ -1,5 +1,5 @@
 <template>
-	<button @click="$emit('click')" class="w-10 h-10 cursor-pointer flex items-center justify-center rounded-full border text-xl font-bold text-gray-600 hover:bg-gray-100 transition">+</button>
+	<button @click="$emit('click')" class="w-10 h-10 cursor-pointer flex items-center justify-center rounded-full border bg-white text-xl font-bold text-gray-600 hover:bg-gray-100 hover:text-gray-800 transition">+</button>
 </template>
 
 <script>

--- a/vue-src/src/views/HomeView.vue
+++ b/vue-src/src/views/HomeView.vue
@@ -1,20 +1,24 @@
 <template>
-	<div class="flex flex-col text-center mx-auto">
-		<label class="text-6xl font-extralight">Motusolve</label>
+	<div class="flex flex-col items-center text-center space-y-6">
+		<h1 class="text-6xl font-extralight">Motusolve</h1>
 
-		<div class="mx-auto">
-			<label>Mot à trouver</label>
-			<LetterGroup v-model="wordToFind" />
+		<div class="mx-auto bg-white p-6 rounded shadow-md space-y-4">
+			<div class="space-y-2">
+				<label class="block">Mot à trouver</label>
+				<LetterGroup v-model="wordToFind" />
+			</div>
 
-			<label>Lettres existantes</label>
-			<LetterGroup v-model="lettersHints" />
+			<div class="space-y-2">
+				<label class="block">Lettres existantes</label>
+				<LetterGroup v-model="lettersHints" />
+			</div>
 
-			<button @click="search" class="p-3 bg-amber-600 rounded text-white cursor-pointer">Lancer la recherche</button>
+			<button @click="search" class="p-3 bg-amber-600 rounded text-white cursor-pointer hover:bg-amber-700 transition">Lancer la recherche</button>
 
-			<div v-if="results.length > 0">
-				<label>Résultats :</label>
+			<div v-if="results.length > 0" class="space-y-2">
+				<label class="block">Résultats :</label>
 
-				<div class="flex flex-wrap">
+				<div class="flex flex-wrap justify-center">
 					<label v-for="result in results" :key="result" class="p-2 m-1 rounded bg-amber-400">{{ result }}</label>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- adjust page body style and load Inter font
- refine layout and spacing in `HomeView`
- tweak input and button visuals
- style letter groups with a subtle background

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6883a1dc43848329af5f7ca326274410